### PR TITLE
Plugin improvements

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
   "private": false,
   "scripts": {
     "build": "babel src/ -d lib/ --delete-dir-on-start",
-    "prepare": "yarn run build"
+    "prepare": "yarn run build",
+    "start-dev": "yarn run build -w --verbose"
   },
   "files": [
     "/lib"

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -58,12 +58,20 @@ export default function getAppSyncConfig(context, appSyncConfig) {
   };
 
   const makeResolver = (resolver) => ({
-    kind: 'UNIT',
+    kind: resolver.kind || 'UNIT',
     fieldName: resolver.field,
     typeName: resolver.type,
     dataSourceName: resolver.dataSource,
+    functions: resolver.functions,
     requestMappingTemplateLocation: resolver.request,
     responseMappingTemplateLocation: resolver.response,
+  });
+
+  const makeFunctionConfiguration = (functionConfiguration) => ({
+    dataSourceName: functionConfiguration.dataSource,
+    name: functionConfiguration.name,
+    requestMappingTemplateLocation: functionConfiguration.request,
+    responseMappingTemplateLocation: functionConfiguration.response,
   });
 
   const makeAuthType = (authType) => {
@@ -103,6 +111,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
     schema: getFileMap(context.serverless.config.servicePath, appSyncConfig.schema || 'schema.graphql'),
     resolvers: appSyncConfig.mappingTemplates.flat().map(makeResolver),
     dataSources: appSyncConfig.dataSources.flat().map(makeDataSource).filter((v) => v !== null),
+    functions: appSyncConfig.functionConfigurations.flat().map(makeFunctionConfiguration),
     mappingTemplates: appSyncConfig.mappingTemplates.flat().reduce((acc, template) => {
       const requestTemplate = template.request || `${template.type}.${template.field}.request.vtl`;
       if (!find(acc, (e) => e.path === requestTemplate)) {

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -22,6 +22,16 @@ export default function getAppSyncConfig(context, appSyncConfig) {
       type: source.type,
     };
 
+    /**
+     * Returns the tableName resolving reference
+     */
+    const getTableName = (table) => {
+      if (table && table.Ref) {
+        return get(context.serverless.service, `resources.Resources.${table.Ref}.Properties.TableName`);
+      }
+      return table;
+    };
+
     switch (source.type) {
       case 'AMAZON_DYNAMODB': {
         const { port } = context.options.dynamoDb;
@@ -30,7 +40,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           config: {
             endpoint: `http://localhost:${port}`,
             region: 'localhost',
-            tableName: source.config.tableName, // FIXME: Handle Ref:
+            tableName: getTableName(source.config.tableName),
           },
         };
       }

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -7,11 +7,13 @@ import { find, get } from 'lodash';
 import path from 'path';
 
 export default function getAppSyncConfig(context, appSyncConfig) {
-  const cfg = appSyncConfig;
   // Flattening params
-  cfg.mappingTemplates = cfg.mappingTemplates.flat();
-  cfg.functionConfigurations = cfg.functionConfigurations.flat();
-  cfg.dataSources = cfg.dataSources.flat();
+  const cfg = {
+    ...appSyncConfig,
+    mappingTemplates: (appSyncConfig.mappingTemplates || []).flat(),
+    functionConfigurations: (appSyncConfig.functionConfigurations || []).flat(),
+    dataSources: (appSyncConfig.dataSources || []).flat(),
+  };
 
   const getFileMap = (basePath, filePath) => ({
     path: filePath,

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -29,11 +29,17 @@ export default function getAppSyncConfig(context, appSyncConfig) {
     };
 
     /**
-     * Returns the tableName resolving reference
+     * Returns the tableName resolving reference. Throws exception if reference is not found
      */
     const getTableName = (table) => {
       if (table && table.Ref) {
-        return get(context.serverless.service, `resources.Resources.${table.Ref}.Properties.TableName`);
+        const tableName = get(context.serverless.service, `resources.Resources.${table.Ref}.Properties.TableName`);
+
+        if (!tableName) {
+          throw new Error(`Unable to find table Reference for ${table} inside Serverless resources`);
+        }
+
+        return tableName;
       }
       return table;
     };

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -101,9 +101,9 @@ export default function getAppSyncConfig(context, appSyncConfig) {
   return {
     appSync: makeAppSync(),
     schema: getFileMap(context.serverless.config.servicePath, appSyncConfig.schema || 'schema.graphql'),
-    resolvers: appSyncConfig.mappingTemplates.map(makeResolver),
-    dataSources: appSyncConfig.dataSources.map(makeDataSource).filter((v) => v !== null),
-    mappingTemplates: appSyncConfig.mappingTemplates.reduce((acc, template) => {
+    resolvers: appSyncConfig.mappingTemplates.flat().map(makeResolver),
+    dataSources: appSyncConfig.dataSources.flat().map(makeDataSource).filter((v) => v !== null),
+    mappingTemplates: appSyncConfig.mappingTemplates.flat().reduce((acc, template) => {
       const requestTemplate = template.request || `${template.type}.${template.field}.request.vtl`;
       if (!find(acc, (e) => e.path === requestTemplate)) {
         acc.push(getFileMap(mappingTemplatesLocation, requestTemplate));


### PR DESCRIPTION
With this PR, I'm adding:
1- A start-dev command to be used for local development (watches and rebuilds the files, so it can be used with `yarn link`)
2- Handling of table ref inside datasources
3- Support `PIPELINE` resolvers
4- Flatten mappingTemplates, functionConfigurations, dataSources arrays so that we can split the `serverless.yaml` configuration in multiple files (eg. : 
```
    mappingTemplates:
      - ${file(./data/type1/templates.yml)}
      - ${file(./data/type2/templates.yml)}
```

Feedback welcome as always.

Thanks for the effort!