### PR TITLE
Support external dynamodb endpoint and define default AWS credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,14 @@ This plugin relies on your serverless yml file and on the `serverless-offline` p
 
 ````yml
 plugins:
-  - serverless-dynamodb-local # only if you need dynamodb resolvers
+  - serverless-dynamodb-local # only if you need dynamodb resolvers and you don't have an external dynamodb
   - serverless-appsync-simulator
   - serverless-offline
 ````
 
 **Note:** Order is important `serverless-appsync-simulator` must go **before** `serverless-offline`
 
-To start the simulator, run the followin command:
+To start the simulator, run the following command:
 ````bash
 sls offline start
 ````
@@ -46,19 +46,24 @@ Serverless: GraphiQl: http://localhost:20002
 
 Put options under `custom.appsync-simulator` in your `serverless.yml` file
 
-| option | default | description |
-|--------|---------|-------------|
-| apiKey   | `0123456789`   | When using `API_KEY` as authentication type, the key to authenticate to the endpoint. |
-| port   | 20002   | AppSync operations port |
-| wsPort | 20003   | AppSync subscriptions port |
-| location | . (base directory)   | Location of the lambda functions handlers. |
-
+| option                   | default               | description                                                                                                                    |
+| ------------------------ | --------------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| apiKey                   | `0123456789`          | When using `API_KEY` as authentication type, the key to authenticate to the endpoint.                                          |
+| port                     | 20002                 | AppSync operations port                                                                                                        |
+| wsPort                   | 20003                 | AppSync subscriptions port                                                                                                     |
+| location                 | . (base directory)    | Location of the lambda functions handlers.                                                                                     |
+| dynamoDb.endpoint        | http://localhost:8000 | Dynamodb endpoint. Specify it if you're not using serverless-dynamodb-local. Otherwise, port is taken from dynamodb-local conf |
+| dynamoDb.accessKeyId     | DEFAULT_ACCESS_KEY    | AWS Access Key ID to access DynamoDB                                                                                           |
+| dynamoDb.secretAccessKey | DEFAULT_SECRET        | AWS Secret Key to access DynamoDB                                                                                              |
 Example:
 
 ````yml
 custom:
   appsync-simulator:
     location: '.webpack/service' # use webpack build directory
+    dynamoDb:
+      endpoint: 'http://my-custom-dynamo:8000
+
 ````
 
 # Caveats

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ custom:
   appsync-simulator:
     location: '.webpack/service' # use webpack build directory
     dynamoDb:
-      endpoint: 'http://my-custom-dynamo:8000
+      endpoint: 'http://my-custom-dynamo:8000'
 
 ````
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Put options under `custom.appsync-simulator` in your `serverless.yml` file
 | wsPort                   | 20003                 | AppSync subscriptions port                                                                                                     |
 | location                 | . (base directory)    | Location of the lambda functions handlers.                                                                                     |
 | dynamoDb.endpoint        | http://localhost:8000 | Dynamodb endpoint. Specify it if you're not using serverless-dynamodb-local. Otherwise, port is taken from dynamodb-local conf |
+| dynamoDb.region          | localhost             | Dynamodb region. Specify it if you're connecting to a remote Dynamodb intance.                                                 |
 | dynamoDb.accessKeyId     | DEFAULT_ACCESS_KEY    | AWS Access Key ID to access DynamoDB                                                                                           |
 | dynamoDb.secretAccessKey | DEFAULT_SECRET        | AWS Secret Key to access DynamoDB                                                                                              |
 Example:

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -24,13 +24,20 @@ export default function getAppSyncConfig(context, appSyncConfig) {
 
     switch (source.type) {
       case 'AMAZON_DYNAMODB': {
-        const { port } = context.options.dynamoDb;
+        const {
+          endpoint,
+          accessKeyId,
+          secretAccessKey,
+        } = context.options.dynamoDb;
+
         return {
           ...dataSource,
           config: {
-            endpoint: `http://localhost:${port}`,
+            endpoint,
             region: 'localhost',
             tableName: source.config.tableName, // FIXME: Handle Ref:
+            accessKeyId,
+            secretAccessKey,
           },
         };
       }

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -26,6 +26,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
       case 'AMAZON_DYNAMODB': {
         const {
           endpoint,
+          region,
           accessKeyId,
           secretAccessKey,
         } = context.options.dynamoDb;
@@ -34,7 +35,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           ...dataSource,
           config: {
             endpoint,
-            region: 'localhost',
+            region,
             tableName: source.config.tableName, // FIXME: Handle Ref:
             accessKeyId,
             secretAccessKey,

--- a/src/index.js
+++ b/src/index.js
@@ -19,7 +19,9 @@ class ServerlessAppSyncSimulator {
         wsPort: 20003,
         location: '.',
         dynamoDb: {
-          port: get(this.serverless.service, 'custom.dynamodb.start.port', 8000),
+          endpoint: `http://localhost:${get(this.serverless.service, 'custom.dynamodb.start.port', 8000)}`,
+          accessKeyId: 'DEFAULT_ACCESS_KEY',
+          secretAccessKey: 'DEFAULT_SECRET',
         },
       },
       get(this.serverless.service, 'custom.appsync-simulator', {}),

--- a/src/index.js
+++ b/src/index.js
@@ -20,6 +20,7 @@ class ServerlessAppSyncSimulator {
         location: '.',
         dynamoDb: {
           endpoint: `http://localhost:${get(this.serverless.service, 'custom.dynamodb.start.port', 8000)}`,
+          region: 'localhost',
           accessKeyId: 'DEFAULT_ACCESS_KEY',
           secretAccessKey: 'DEFAULT_SECRET',
         },


### PR DESCRIPTION
Fixes #1 + also allows for a custom DynamoDB endpoint to be set, which defaults to `localhost:{dynamoDbPort}`