### PR TITLE
Correctly infer mapping template name

### DIFF
--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -100,8 +100,8 @@ export default function getAppSyncConfig(context, appSyncConfig) {
     typeName: resolver.type,
     dataSourceName: resolver.dataSource,
     functions: resolver.functions,
-    requestMappingTemplateLocation: resolver.request,
-    responseMappingTemplateLocation: resolver.response,
+    requestMappingTemplateLocation: resolver.request || `${resolver.type}.${resolver.field}.request.vtl`,
+    responseMappingTemplateLocation: resolver.response || `${resolver.type}.${resolver.field}.response.vtl`,
   });
 
   const makeFunctionConfiguration = (functionConfiguration) => ({


### PR DESCRIPTION
I was getting error `Missing mapping template undefined` when I tried to let the plugin infer the names of the request and response mapping templates.