### PR TITLE
Fix problem where no resources section results in a runtime error

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -152,7 +152,7 @@ class ServerlessAppSyncSimulator {
   resolveResources(toBeResolved) {
     // Pass Resources to allow Fn::GetAtt resolution
     const node = {
-      Resources: this.serverless.service.resources.Resources || {},
+      Resources: this.serverless.service.resources?.Resources || {},
       toBeResolved,
     };
     const evaluator = new NodeEvaluator(node, this.resourceResolvers);


### PR DESCRIPTION
Fixes a problem where the plugin emits an error when trying to process a `serverless.yml` with no `resources` section. Before this fix, such serverless config would emit:

    AppSync Simulator: TypeError: Cannot read property 'Resources' of undefined

The fix uses the optional chaining operator and will force Babel to produce proper guards in the generated library code.