### PR TITLE
Add importValueMap option and key-value mock notation

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -116,9 +116,19 @@ class ServerlessAppSyncSimulator {
       {},
     );
 
+    const keyValueArrayToObject = (mapping) => {
+      if (Array.isArray(mapping)) {
+        return mapping.reduce((acc, { key, value }) => (
+          { ...acc, [key]: value }
+        ), {});
+      }
+      return mapping;
+    };
+
     this.resourceResolvers = {
-      RefResolvers: { ...refResolvers, ...this.options.refMap },
-      'Fn::GetAttResolvers': this.options.getAttMap,
+      RefResolvers: { ...refResolvers, ...keyValueArrayToObject(this.options.refMap) },
+      'Fn::GetAttResolvers': keyValueArrayToObject(this.options.getAttMap),
+      'Fn::ImportValueResolvers': keyValueArrayToObject(this.options.importValueMap),
     };
   }
 
@@ -131,6 +141,7 @@ class ServerlessAppSyncSimulator {
         location: '.',
         refMap: {},
         getAttMap: {},
+        importValueMap: {},
         dynamoDb: {
           endpoint: `http://localhost:${get(
             this.serverless.service,


### PR DESCRIPTION
At @purple-technology we use `Fn::ImportValue` because of our serverless monorepo approach, so adding support for `Fn::ImportValue` mocking is quite crucial for us.

Also we use a lot of serverless variables in the import names, so I added also implementation of key-value notation. 

README:
> ### Key-value mock notation
> 
> In some special cases you will need to use key-value mock nottation.
> Good example can be case when you need to include serverless stage value (`${self:provider.stage}`) in the import name.
> 
> *This notation can be used with all mocks - `refMap`, `getAttMap` and `importValueMap`*
> 
> ```yaml
> provider:
>   environment:
>     FINISH_ACTIVITY_FUNCTION_ARN:
>       Fn::ImportValue: other-service-api-${self:provider.stage}-url
> 
> custom:
>   serverless-appsync-simulator:
>     importValueMap:
>       - key: other-service-api-${self:provider.stage}-url
>         value: "https://other.api.url.com/graphql"
> ```