### PR TITLE
Pass all resources when resolving them

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -164,9 +164,9 @@ class ServerlessAppSyncSimulator {
    * Resolves resourses through `Ref:` or `Fn:GetAtt`
    */
   resolveResources(toBeResolved) {
-    // Pass Resources to allow Fn::GetAtt resolution
+    // Pass all resources to allow Fn::GetAtt and Conditions resolution
     const node = {
-      Resources: this.serverless.service.resources?.Resources || {},
+      ...this.serverless.service.resources,
       toBeResolved,
     };
     const evaluator = new NodeEvaluator(node, this.resourceResolvers);

--- a/src/index.js
+++ b/src/index.js
@@ -166,8 +166,6 @@ class ServerlessAppSyncSimulator {
   resolveResources(toBeResolved) {
     // Pass all resources to allow Fn::GetAtt and Conditions resolution
     const node = {
-      // Conditions must appear before Resources, see https://github.com/bboure/serverless-appsync-simulator/pull/31#issuecomment-633872077
-      Conditions: this.serverless.service.resources?.Conditions || {},
       ...this.serverless.service.resources,
       toBeResolved,
     };

--- a/src/index.js
+++ b/src/index.js
@@ -166,6 +166,8 @@ class ServerlessAppSyncSimulator {
   resolveResources(toBeResolved) {
     // Pass all resources to allow Fn::GetAtt and Conditions resolution
     const node = {
+      // Conditions must appear before Resources, see https://github.com/bboure/serverless-appsync-simulator/pull/31#issuecomment-633872077
+      Conditions: this.serverless.service.resources?.Conditions || {},
       ...this.serverless.service.resources,
       toBeResolved,
     };


### PR DESCRIPTION
Fixes error:
`AppSync Simulator: TypeError: Cannot read property 'wrappedObject' of undefined`

`cfn-resolver-lib` needs to be able to read all resources when checking CloudFormation Conditions, because Conditions are defined in the root of the configurations. This PR ensures that all resources are passed to the node evaluator, instead of just the `Resources` node.

I've tested it in my private repo, and this was needed in order to not get an `undefined TypeError`.

Note: in my testing, I've also noticed that if resources are defined in multiple different yaml-files, and they reference each other, all the "top most" resource files needs the Conditions defined. Ie. with the resources:
- `resource-a.yml`
- `resource-b.yml`
where `resource-a` references `resource-b`, and `resource-b` relies on a Condition, the Condition MUST be defined in `resource-a`, and not just in `resource-b`. I haven't had time to figure out why, and even if this is an issue with this package, or if it is an issue with `cfn-resolver-lib`.