### PR TITLE
Added a way to invoke external functions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Put options under `custom.appsync-simulator` in your `serverless.yml` file
 | refMap                   | {}                    | A mapping of [resource resolutions](#resource-cloudformation-functions-resolution) for the `Ref` function                                                           |
 | getAttMap                | {}                    | A mapping of [resource resolutions](#resource-cloudformation-functions-resolution) for the `GetAtt` function                                                        |
 | importValueMap           | {}                    | A mapping of [resource resolutions](#resource-cloudformation-functions-resolution) for the `ImportValue` function                                                   |
-| fucntions                | {}                    | A mapping of [external functions](#functions) for providing invoke url for external fucntions                                                                                |
+| functions                | {}                    | A mapping of [external functions](#functions) for providing invoke url for external fucntions                                                                                |
 | dynamoDb.endpoint        | http://localhost:8000 | Dynamodb endpoint. Specify it if you're not using serverless-dynamodb-local. Otherwise, port is taken from dynamodb-local conf                                      |
 | dynamoDb.region          | localhost             | Dynamodb region. Specify it if you're connecting to a remote Dynamodb intance.                                                                                      |
 | dynamoDb.accessKeyId     | DEFAULT_ACCESS_KEY    | AWS Access Key ID to access DynamoDB                                                                                                                                |
@@ -208,7 +208,7 @@ When a function is not defined withing the current serverless file you can still
 
 ```yaml
 custom:
-  appSync:
+  appsync-simulator:
     functions:
       addUser:
         url: http://localhost:3016/2015-03-31/functions/addUser/invocations

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Put options under `custom.appsync-simulator` in your `serverless.yml` file
 | refMap                   | {}                    | A mapping of [resource resolutions](#resource-cloudformation-functions-resolution) for the `Ref` function                                                           |
 | getAttMap                | {}                    | A mapping of [resource resolutions](#resource-cloudformation-functions-resolution) for the `GetAtt` function                                                        |
 | importValueMap           | {}                    | A mapping of [resource resolutions](#resource-cloudformation-functions-resolution) for the `ImportValue` function                                                   |
+| fucntions                | {}                    | A mapping of [external functions](#functions) for providing invoke url for external fucntions                                                                                |
 | dynamoDb.endpoint        | http://localhost:8000 | Dynamodb endpoint. Specify it if you're not using serverless-dynamodb-local. Otherwise, port is taken from dynamodb-local conf                                      |
 | dynamoDb.region          | localhost             | Dynamodb region. Specify it if you're connecting to a remote Dynamodb intance.                                                                                      |
 | dynamoDb.accessKeyId     | DEFAULT_ACCESS_KEY    | AWS Access Key ID to access DynamoDB                                                                                                                                |
@@ -201,6 +202,20 @@ For now, the supported resources to be automatically resovled by `Ref:` are:
 - S3 Buckets
 
 Feel free to open a PR or an issue to extend them as well.
+
+# External functions
+When a function is not defined withing the current serverless file you can still call it by providing an invoke url which should point to a REST method (must be post).
+
+```yaml
+custom:
+  appSync:
+    functions:
+      addUser:
+        url: http://localhost:3016/2015-03-31/functions/addUser/invocations
+      addPost:
+        url: https://jsonplaceholder.typicode.com/posts
+```
+
 
 # Supported Resolver types
 

--- a/examples/external-functions/mapping-templates/Query.getPosts.request.vtl
+++ b/examples/external-functions/mapping-templates/Query.getPosts.request.vtl
@@ -1,0 +1,4 @@
+{
+    "version": "2018-05-29",
+    "operation": "Invoke"
+}

--- a/examples/external-functions/mapping-templates/Query.getPosts.response.vtl
+++ b/examples/external-functions/mapping-templates/Query.getPosts.response.vtl
@@ -1,0 +1,1 @@
+$util.toJson($context.result)

--- a/examples/external-functions/package.json
+++ b/examples/external-functions/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "external-functions",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "scripts": {
+    "offline": "sls offline start"
+  },
+  "dependencies": {
+    "serverless-appsync-plugin": "^1.3.1",
+    "serverless-offline": "^6.7.0"
+  }
+}

--- a/examples/external-functions/schema.graphql
+++ b/examples/external-functions/schema.graphql
@@ -1,0 +1,14 @@
+type Post {
+    userId: Int!
+    id: Int!
+    title: String!
+    body: String!
+}
+
+type Query {
+  getPosts: [Post]!
+}
+
+schema {
+  query: Query
+}

--- a/examples/external-functions/serverless.yml
+++ b/examples/external-functions/serverless.yml
@@ -9,6 +9,11 @@ plugins:
     - serverless-appsync-plugin
 
 custom:
+    appsync-simulator:
+        functions:
+            myLambda:
+                url: https://jsonplaceholder.typicode.com/posts
+                method: GET
     appSync:
         name: Test
         schema: schema.graphql
@@ -26,7 +31,3 @@ custom:
               config:
                   functionName: myLambda
                   lambdaFunctionArn: "arn:aws:lambda:${self:provider.region}:*:getPosts-graphql"
-        functions:
-            myLambda:
-                url: https://jsonplaceholder.typicode.com/posts
-                method: GET

--- a/examples/external-functions/serverless.yml
+++ b/examples/external-functions/serverless.yml
@@ -1,0 +1,32 @@
+service: mapping-templates
+provider:
+    name: aws
+    region: eu-west-1
+
+plugins:
+    - serverless-offline
+    - serverless-appsync-simulator
+    - serverless-appsync-plugin
+
+custom:
+    appSync:
+        name: Test
+        schema: schema.graphql
+        authenticationType: AWS_IAM
+        mappingTemplatesLocation: mapping-templates
+        mappingTemplates:
+            - dataSource: MyLambda
+              type: Query
+              field: getPosts
+              request: Query.getPosts.request.vtl
+              response: Query.getPosts.response.vtl
+        dataSources:
+            - type: AWS_LAMBDA
+              name: MyLambda
+              config:
+                  functionName: myLambda
+                  lambdaFunctionArn: "arn:aws:lambda:${self:provider.region}:*:getPosts-graphql"
+        functions:
+            myLambda:
+                url: https://jsonplaceholder.typicode.com/posts
+                method: GET

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -2,6 +2,7 @@ import {
   AmplifyAppSyncSimulatorAuthenticationType as AuthTypes,
 } from 'amplify-appsync-simulator';
 import { invoke } from 'amplify-nodejs-function-runtime-provider/lib/utils/invoke';
+import axios from 'axios';
 import fs from 'fs';
 import { forEach } from 'lodash';
 import path from 'path';
@@ -60,6 +61,19 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           );
           return null;
         }
+
+        const conf = appSyncConfig;
+        if (conf.functions && conf.functions[functionName] !== undefined) {
+          const func = conf.functions[functionName];
+          return {
+            ...dataSource,
+            invoke: async (payload) => {
+              const result = await axios.post(func.url, payload);
+              return result.data;
+            }
+          }
+        }
+
         const func = context.serverless.service.functions[functionName];
         if (func === undefined) {
           context.plugin.log(
@@ -68,6 +82,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           );
           return null;
         }
+
         return {
           ...dataSource,
           invoke: (payload) => invoke({

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -72,6 +72,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
                 url: func.url,
                 method: func.method,
                 data: payload,
+                validateStatus: false,
               });
               return result.data;
             }

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -68,7 +68,11 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           return {
             ...dataSource,
             invoke: async (payload) => {
-              const result = await axios.post(func.url, payload);
+              const result = await axios.request({
+                url: func.url,
+                method: func.method,
+                data: payload,
+              });
               return result.data;
             }
           }

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -62,7 +62,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           return null;
         }
 
-        const conf = appSyncConfig;
+        const conf = context.options;
         if (conf.functions && conf.functions[functionName] !== undefined) {
           const func = conf.functions[functionName];
           return {


### PR DESCRIPTION
The plugin currently does not support functions that are not defined within the current serverless.yml.
This commit adds a way to define an endpoint for these functions so the can be called anyway as a rest call.
One can make a function callable by defining events.http section.

