### PR TITLE
link to amplify-appsync-simulator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-This serverless plugin is a wrapper for [amplify-appsync-simulator](amplify-appsync-simulator) made for testing AppSync APIs built with [serverless-appsync-plugin](https://github.com/sid88in/serverless-appsync-plugin).
+This serverless plugin is a wrapper for [amplify-appsync-simulator](https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-appsync-simulator) made for testing AppSync APIs built with [serverless-appsync-plugin](https://github.com/sid88in/serverless-appsync-plugin).
 
 
 # Requires


### PR DESCRIPTION
I added it because there was no link to the amplify-appsync-simulator website.

https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-appsync-simulator