### PR TITLE
add region in resources resolvers

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -125,6 +125,8 @@ class ServerlessAppSyncSimulator {
       RefResolvers: {
         ...refResolvers,
         ...keyValueArrayToObject(this.options.refMap),
+        // Add region for cfn-resolver-lib GetAZs
+        'AWS::Region': this.serverless.service.provider.region,
       },
       'Fn::GetAttResolvers': keyValueArrayToObject(this.options.getAttMap),
       'Fn::ImportValueResolvers': keyValueArrayToObject(


### PR DESCRIPTION
Add  `AWS::Region` in ref of resource resolvers to allow `cfn-resolver-lib` to map Availability Zones through `FnGetAZs`.  
Closes https://github.com/bboure/serverless-appsync-simulator/issues/55