### PR TITLE
document the undocumented 'method' param that defaults to 'get'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![semantic-release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg)](https://github.com/semantic-release/semantic-release) ![Release](https://github.com/bboure/serverless-appsync-simulator/workflows/Release/badge.svg) <!-- ALL-CONTRIBUTORS-BADGE:START - Do not remove or modify this section -->
 [![All Contributors](https://img.shields.io/badge/all_contributors-11-orange.svg?style=flat-square)](#contributors-)
+
 <!-- ALL-CONTRIBUTORS-BADGE:END -->
 
 This serverless plugin is a wrapper for [amplify-appsync-simulator](https://github.com/aws-amplify/amplify-cli/tree/master/packages/amplify-appsync-simulator) made for testing AppSync APIs built with [serverless-appsync-plugin](https://github.com/sid88in/serverless-appsync-plugin).
@@ -224,7 +225,7 @@ Feel free to open a PR or an issue to extend them as well.
 
 # External functions
 
-When a function is not defined withing the current serverless file you can still call it by providing an invoke url which should point to a REST method (must be post).
+When a function is not defined withing the current serverless file you can still call it by providing an invoke url which should point to a REST method. Make sure you specify "get" or "post" for the method. Default is "get", but you probably want "post".
 
 ```yaml
 custom:
@@ -232,8 +233,10 @@ custom:
     functions:
       addUser:
         url: http://localhost:3016/2015-03-31/functions/addUser/invocations
+        method: post
       addPost:
         url: https://jsonplaceholder.typicode.com/posts
+        method: post
 ```
 
 # Supported Resolver types


### PR DESCRIPTION
Hi there,

So the functions section has an additional parameter that's accepted called "method", but it's not documented.

https://github.com/bboure/serverless-appsync-simulator/blob/e4be7c6e7ed45f788023e04d7ef40d2f45531659/src/getAppSyncConfig.js#L92

If the user does not specify a value for this parameter, axios uses a GET request by default. This is probably not what users want, and the current documentation makes it seem like it would use a POST, but it doesn't.

I didn't change the actual implementation in case users are relying on the default setting, but I want to make this clear for future users.

Cheers!