### PR TITLE
add sessionToken to dynamoDb options, tests updated

### DIFF
--- a/src/__tests__/__snapshots__/getAppSyncConfig.js.snap
+++ b/src/__tests__/__snapshots__/getAppSyncConfig.js.snap
@@ -128,6 +128,7 @@ Array [
       "endpoint": "http://localhost:8000",
       "region": "localhost",
       "secretAccessKey": "DEFAULT_SECRET",
+      "sessionToken": "DEFAULT_SESSION_TOKEN",
       "tableName": "myTable",
     },
     "name": "dynamodb",

--- a/src/__tests__/getAppSyncConfig.js
+++ b/src/__tests__/getAppSyncConfig.js
@@ -104,6 +104,7 @@ describe('getAppSyncConfig', () => {
             region: 'localhost',
             accessKeyId: 'DEFAULT_ACCESS_KEY',
             secretAccessKey: 'DEFAULT_SECRET',
+            sessionToken: 'DEFAULT_SESSION_TOKEN',
           },
         },
         serverless: {

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -59,6 +59,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           region,
           accessKeyId,
           secretAccessKey,
+          sessionToken,
         } = context.options.dynamoDb;
 
         return {
@@ -68,6 +69,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
             region,
             accessKeyId,
             secretAccessKey,
+            sessionToken,
             tableName: source.config.tableName,
           },
         };


### PR DESCRIPTION
As you advice to me in this issue: [https://github.com/bboure/serverless-appsync-simulator/issues/76](url) I have implemented and tested the connection with my dybamoDb with session token and It work fine because amplify-appsync-simulator is just able to accept the sessionToken parameter!