### PR TITLE
feat: dynamoDb options is able to accept sessionToken

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Put options under `custom.appsync-simulator` in your `serverless.yml` file
 | dynamoDb.accessKeyId     | DEFAULT_ACCESS_KEY         | AWS Access Key ID to access DynamoDB                                                                                                                                |
 | dynamoDb.secretAccessKey | DEFAULT_SECRET             | AWS Secret Key to access DynamoDB                                                                                                                                   |
 | dynamoDb.sessionToken    | DEFAULT_ACCESS_TOKEEN      | AWS Session Token to access DynamoDB, only if you have  temporary security credentials configured on AWS                                                            |
-| dynamoDb.*               |                            | You can add every configuration accepted by DynamoDB                                                                                                                |
+| dynamoDb.*               |                            | You can add every configuration accepted by [DynamoDB SDK](https://docs.aws.amazon.com/AWSJavaScriptSDK/latest/AWS/DynamoDB.html#constructor-property)                                                                                |
 | watch                    | - \*.graphql<br/> - \*.vtl | Array of glob patterns to watch for hot-reloading.                                                                                                                  |
 
 Example:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ Put options under `custom.appsync-simulator` in your `serverless.yml` file
 | dynamoDb.region          | localhost                  | Dynamodb region. Specify it if you're connecting to a remote Dynamodb intance.                                                                                      |
 | dynamoDb.accessKeyId     | DEFAULT_ACCESS_KEY         | AWS Access Key ID to access DynamoDB                                                                                                                                |
 | dynamoDb.secretAccessKey | DEFAULT_SECRET             | AWS Secret Key to access DynamoDB                                                                                                                                   |
+| dynamoDb.sessionToken    | DEFAULT_ACCESS_TOKEEN      | AWS Session Token to access DynamoDB, only if you have  temporary security credentials configured on AWS                                                            |
+| dynamoDb.*               |                            | You can add every configuration accepted by DynamoDB                                                                                                                |
 | watch                    | - \*.graphql<br/> - \*.vtl | Array of glob patterns to watch for hot-reloading.                                                                                                                  |
 
 Example:

--- a/src/__tests__/__snapshots__/getAppSyncConfig.js.snap
+++ b/src/__tests__/__snapshots__/getAppSyncConfig.js.snap
@@ -128,6 +128,7 @@ Array [
       "endpoint": "http://localhost:8000",
       "region": "localhost",
       "secretAccessKey": "DEFAULT_SECRET",
+      "sessionToken": "DEFAULT_SESSION_TOKEN",
       "tableName": "myTable",
     },
     "name": "dynamodb",

--- a/src/__tests__/getAppSyncConfig.js
+++ b/src/__tests__/getAppSyncConfig.js
@@ -104,6 +104,7 @@ describe('getAppSyncConfig', () => {
             region: 'localhost',
             accessKeyId: 'DEFAULT_ACCESS_KEY',
             secretAccessKey: 'DEFAULT_SECRET',
+            sessionToken: 'DEFAULT_SESSION_TOKEN',
           },
         },
         serverless: {

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -54,22 +54,10 @@ export default function getAppSyncConfig(context, appSyncConfig) {
 
     switch (source.type) {
       case 'AMAZON_DYNAMODB': {
-        const {
-          endpoint,
-          region,
-          accessKeyId,
-          secretAccessKey,
-          sessionToken,
-        } = context.options.dynamoDb;
-
         return {
           ...dataSource,
           config: {
-            endpoint,
-            region,
-            accessKeyId,
-            secretAccessKey,
-            sessionToken,
+            ...context.options.dynamoDb,
             tableName: source.config.tableName,
           },
         };

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -59,6 +59,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           region,
           accessKeyId,
           secretAccessKey,
+          sessionToken,
         } = context.options.dynamoDb;
 
         return {
@@ -68,6 +69,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
             region,
             accessKeyId,
             secretAccessKey,
+            sessionToken,
             tableName: source.config.tableName,
           },
         };


### PR DESCRIPTION
As you advice to me in this issue: [https://github.com/bboure/serverless-appsync-simulator/issues/76](url) I have implemented and tested the connection with my dybamoDb with session token and It work fine because amplify-appsync-simulator is just able to accept the sessionToken parameter!