### PR TITLE
feat: Support glob pattern and absolute path for schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "cfn-resolver-lib": "^1.1.7",
     "dataloader": "^2.0.0",
     "fb-watchman": "^2.0.1",
+    "globby": "^11.0.3",
     "jest": "^26.6.3",
     "lodash": "^4.17.20",
     "merge-graphql-schemas": "^1.5.8"

--- a/src/__tests__/getAppSyncConfig.js
+++ b/src/__tests__/getAppSyncConfig.js
@@ -6,6 +6,7 @@ describe('getAppSyncConfig', () => {
     const config = {
       name: 'myAPI',
       authenticationType: 'API_KEY',
+      schema: '*.graphql',
       defaultMappingTemplates: {
         request: 'default.request.vtl',
         response: 'default.response.vtl',

--- a/yarn.lock
+++ b/yarn.lock
@@ -4030,7 +4030,7 @@ globby@11.0.0:
     merge2 "^1.3.0"
     slash "^3.0.0"
 
-globby@^11.0.0, globby@^11.0.1:
+globby@^11.0.0, globby@^11.0.1, globby@^11.0.3:
   version "11.0.3"
   resolved "https://registry.yarnpkg.com/globby/-/globby-11.0.3.tgz#9b1f0cb523e171dd1ad8c7b2a9fb4b644b9593cb"
   integrity sha512-ffdmosjA807y7+lA1NM0jELARVmYul/715xiILEjo3hBLPTcirgQNnXECn5g3mtR8TOLCVbkfua1Hpen25/Xcg==


### PR DESCRIPTION
Support glob pattern and absolute path for schema as well as https://github.com/sid88in/serverless-appsync-plugin/pull/399 .
```
custom:
  appSync:
    schema:
      - path/**/*.graphql
      - /path/to/schema.graphql
```