### PR TITLE
fix: variableMap injection by using regex

### DIFF
--- a/src/data-loaders/RelationalDataLoader.js
+++ b/src/data-loaders/RelationalDataLoader.js
@@ -106,7 +106,7 @@ const injectVariables = (statement, req) => {
     return statement;
   }
   const result = Object.keys(variableMap).reduce((statmnt, key) => {
-    // Adds "g" for replaceAll effect
+    // Adds 'g' for replaceAll effect
     var re = new RegExp(key, "g");
     if (variableMap[key] === null || typeof variableMap[key] == 'boolean') {
       return statmnt.replace(re, `${variableMap[key]}`);

--- a/src/data-loaders/RelationalDataLoader.js
+++ b/src/data-loaders/RelationalDataLoader.js
@@ -106,6 +106,7 @@ const injectVariables = (statement, req) => {
     return statement;
   }
   const result = Object.keys(variableMap).reduce((statmnt, key) => {
+    // Adds "g" for replaceAll effect
     var re = new RegExp(key, "g");
     if (variableMap[key] === null || typeof variableMap[key] == 'boolean') {
       return statmnt.replace(re, `${variableMap[key]}`);

--- a/src/data-loaders/RelationalDataLoader.js
+++ b/src/data-loaders/RelationalDataLoader.js
@@ -106,11 +106,12 @@ const injectVariables = (statement, req) => {
     return statement;
   }
   const result = Object.keys(variableMap).reduce((statmnt, key) => {
+    var re = new RegExp(key, "g");
     if (variableMap[key] === null || typeof variableMap[key] == 'boolean') {
-      return statmnt.replaceAll(key, `${variableMap[key]}`);
+      return statmnt.replace(re, `${variableMap[key]}`);
     }
     // @TODO: Differentiate number from string inputs...
-    return statmnt.replaceAll(key, `'${variableMap[key]}'`);
+    return statmnt.replace(re, `'${variableMap[key]}'`);
   }, statement);
   return result;
 };

--- a/src/data-loaders/RelationalDataLoader.js
+++ b/src/data-loaders/RelationalDataLoader.js
@@ -107,7 +107,7 @@ const injectVariables = (statement, req) => {
   }
   const result = Object.keys(variableMap).reduce((statmnt, key) => {
     // Adds 'g' for replaceAll effect
-    var re = new RegExp(key, "g");
+    var re = new RegExp(key, 'g');
     if (variableMap[key] === null || typeof variableMap[key] == 'boolean') {
       return statmnt.replace(re, `${variableMap[key]}`);
     }


### PR DESCRIPTION
Fix for: https://github.com/bboure/serverless-appsync-simulator/issues/126

As `replaceAll` is not supported, we need to use `RegExp` to inject `variableMap`.