### PR TITLE
Update to @aws-amplify/amplify-appsync-simulator >= 2.8.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-appsync-simulator",
-  "version": "0.0.0-development",
+  "version": "0.20.0",
   "main": "lib/index.js",
   "author": "bboure",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "@babel/core": "^7.12.3",
     "@babel/plugin-transform-modules-commonjs": "^7.12.1",
     "@babel/preset-env": "^7.12.1",
-    "@semantic-release/git": "^9.0.0",
     "all-contributors-cli": "^6.19.0",
     "babel-eslint": "^10.1.0",
     "babel-plugin-inline-import": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   ],
   "dependencies": {
     "@graphql-tools/merge": "^8.2.1",
-    "amplify-appsync-simulator": "^1.27.4",
+    "@aws-amplify/amplify-appsync-simulator": "^2.8.0",
     "amplify-nodejs-function-runtime-provider": "^1.1.6",
     "aws-sdk": "^2.792.0",
     "axios": "^0.21.0",

--- a/src/__tests__/__snapshots__/getAppSyncConfig.js.snap
+++ b/src/__tests__/__snapshots__/getAppSyncConfig.js.snap
@@ -192,3 +192,66 @@ $util.toJson($ctx.result)
   },
 ]
 `;
+
+exports[`getAppSyncConfig should generate a valid config even with serverless-appsync-plugin >= 2.2.0 1`] = `
+Object {
+  "additionalAuthenticationProviders": Array [],
+  "apiKey": "123456789",
+  "defaultAuthenticationType": Object {
+    "authenticationType": undefined,
+  },
+  "name": undefined,
+}
+`;
+
+exports[`getAppSyncConfig should generate a valid config even with serverless-appsync-plugin >= 2.2.0 2`] = `
+Object {
+  "content": "type Post {
+  userId: Int!
+  id: Int!
+  title: String!
+  body: String!
+}
+
+type Query {
+  getPost: Post
+  getPosts: [Post]!
+}
+
+schema {
+  query: Query
+}",
+  "path": "schema.graphql",
+}
+`;
+
+exports[`getAppSyncConfig should generate a valid config even with serverless-appsync-plugin >= 2.2.0 3`] = `Array []`;
+
+exports[`getAppSyncConfig should generate a valid config even with serverless-appsync-plugin >= 2.2.0 4`] = `
+Array [
+  Object {
+    "invoke": [Function],
+    "name": "lambda",
+    "type": "AWS_LAMBDA",
+  },
+  Object {
+    "config": Object {
+      "accessKeyId": "DEFAULT_ACCESS_KEY",
+      "endpoint": "http://localhost:8000",
+      "region": "localhost",
+      "secretAccessKey": "DEFAULT_SECRET",
+      "sessionToken": "DEFAULT_SESSION_TOKEN",
+      "tableName": "myTable",
+    },
+    "name": "dynamodb",
+    "type": "AMAZON_DYNAMODB",
+  },
+  Object {
+    "endpoint": "http://127.0.0.1",
+    "name": "http",
+    "type": "HTTP",
+  },
+]
+`;
+
+exports[`getAppSyncConfig should generate a valid config even with serverless-appsync-plugin >= 2.2.0 5`] = `Array []`;

--- a/src/__tests__/getAppSyncConfig.js
+++ b/src/__tests__/getAppSyncConfig.js
@@ -2,6 +2,68 @@ import path from 'path';
 import getAppSyncConfig from '../getAppSyncConfig';
 
 describe('getAppSyncConfig', () => {
+  it('should generate a valid config even with serverless-appsync-plugin >= 2.2.0', () => {
+    const config = {
+      dataSources: {
+        lambda: {
+          type: 'AWS_LAMBDA',
+          name: 'lambda',
+          config: {
+            functionName: 'getPosts',
+          },
+        },
+        dynamodb: {
+          type: 'AMAZON_DYNAMODB',
+          name: 'dynamodb',
+          config: {
+            tableName: 'myTable',
+          },
+        },
+        http: {
+          type: 'HTTP',
+          name: 'http',
+          config: {
+            endpoint: 'http://127.0.0.1',
+          },
+        },
+      },
+    };
+
+    const result = getAppSyncConfig(
+      {
+        options: {
+          apiKey: '123456789',
+          dynamoDb: {
+            endpoint: `http://localhost:8000`,
+            region: 'localhost',
+            accessKeyId: 'DEFAULT_ACCESS_KEY',
+            secretAccessKey: 'DEFAULT_SECRET',
+            sessionToken: 'DEFAULT_SESSION_TOKEN',
+          },
+        },
+        serverless: {
+          config: { servicePath: path.join(__dirname, 'files') },
+          service: {
+            functions: {
+              getPost: {
+                hndler: 'index.handler',
+              },
+              getPosts: {
+                hndler: 'index.handler',
+              },
+            },
+          },
+        },
+      },
+      config,
+    );
+    expect(result.appSync).toMatchSnapshot();
+    expect(result.schema).toMatchSnapshot();
+    expect(result.resolvers).toMatchSnapshot();
+    expect(result.dataSources).toMatchSnapshot();
+    expect(result.functions).toMatchSnapshot();
+  });
+
   it('should generate a valid config', () => {
     const config = {
       name: 'myAPI',

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -143,7 +143,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           url = func.url;
           method = func.method;
         } else {
-          url = `http://localhost:${context.options.lambdaPort}/2015-03-31/functions/${func.name}/invocations`;
+          url = `${context.options.httpProtocol}://${context.options.httpPort}:${context.options.lambdaPort}/2015-03-31/functions/${func.name}/invocations`;
         }
         return {
           ...dataSource,

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -143,7 +143,7 @@ export default function getAppSyncConfig(context, appSyncConfig) {
           url = func.url;
           method = func.method;
         } else {
-          url = `${context.options.httpProtocol}://${context.options.httpPort}:${context.options.lambdaPort}/2015-03-31/functions/${func.name}/invocations`;
+          url = `${context.options.httpProtocol}://${context.options.httpHost}:${context.options.lambdaPort}/2015-03-31/functions/${func.name}/invocations`;
         }
         return {
           ...dataSource,

--- a/src/getAppSyncConfig.js
+++ b/src/getAppSyncConfig.js
@@ -1,4 +1,4 @@
-import { AmplifyAppSyncSimulatorAuthenticationType as AuthTypes } from 'amplify-appsync-simulator';
+import { AmplifyAppSyncSimulatorAuthenticationType as AuthTypes } from '@aws-amplify/amplify-appsync-simulator';
 import axios from 'axios';
 import fs from 'fs';
 import { forEach, isNil, first } from 'lodash';

--- a/src/index.js
+++ b/src/index.js
@@ -46,6 +46,31 @@ class ServerlessAppSyncSimulator {
     }
   }
 
+  getHttpProtocol(context) {
+    // Default serverless-offline httpsProtocol is empty
+    let protocol = 'https';
+    const offlineConfig = context.service.custom['serverless-offline'];
+    // Check if the user has defined a certificate for https as part of their serverless.yml
+    if (offlineConfig != undefined && offlineConfig.httpsProtocol != undefined) {
+      protocol = 'https'
+    }
+
+    return protocol;
+  }
+
+
+  getHttpHost(context) {
+    // Default serverless-offline httpHost is localhost
+    let host = 'localhost';
+    const offlineConfig = context.service.custom['serverless-offline'];
+    // Check if the user has defined a specific host as part of their serverless.yml
+    if (offlineConfig != undefined && offlineConfig.host != undefined) {
+      host = offlineConfig.host;
+    }
+
+    return host;
+  }
+
   getLambdaPort(context) {
     // Default serverless-offline lambdaPort is 3002
     let port = 3002;
@@ -100,6 +125,8 @@ class ServerlessAppSyncSimulator {
       }
 
       this.options.lambdaPort = this.getLambdaPort(this.serverless);
+      this.options.httpPort = this.getHttpPort(this.serverless);
+      this.options.httpProtocol = this.getHttpProtocol(this.serverless);
 
       if (Array.isArray(this.options.watch) && this.options.watch.length > 0) {
         this.watch();

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {
   AmplifyAppSyncSimulator,
   addDataLoader,
-} from 'amplify-appsync-simulator';
+} from '@aws-amplify/amplify-appsync-simulator';
 import { inspect } from 'util';
 import { defaults, get, merge, reduce } from 'lodash';
 import NodeEvaluator from 'cfn-resolver-lib';

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 import {
   AmplifyAppSyncSimulator,
-  addDataLoader,
+  addDataLoader, getDataLoader
 } from '@aws-amplify/amplify-appsync-simulator';
 import { inspect } from 'util';
 import { defaults, get, merge, reduce } from 'lodash';
@@ -26,9 +26,23 @@ class ServerlessAppSyncSimulator {
 
     this.simulators = null;
 
-    addDataLoader('HTTP', HttpDataLoader);
-    addDataLoader('AMAZON_ELASTICSEARCH', ElasticDataLoader);
-    addDataLoader('RELATIONAL_DATABASE', RelationalDataLoader);
+    try {
+      getDataLoader('HTTP');
+    } catch (e) {
+      addDataLoader('HTTP', HttpDataLoader);
+    }
+
+    try {
+      getDataLoader('AMAZON_ELASTICSEARCH');
+    } catch (e) {
+      addDataLoader('AMAZON_ELASTICSEARCH', ElasticDataLoader);
+    }
+
+    try {
+      getDataLoader('RELATIONAL_DATABASE');
+    } catch (e) {
+      addDataLoader('RELATIONAL_DATABASE', RelationalDataLoader);
+    }
 
     this.hooks = {
       'before:offline:start:init': this.startServers.bind(this),

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ class ServerlessAppSyncSimulator {
       }
 
       this.options.lambdaPort = this.getLambdaPort(this.serverless);
-      this.options.httpPort = this.getHttpPort(this.serverless);
+      this.options.httpPort = this.getHttpHost(this.serverless);
       this.options.httpProtocol = this.getHttpProtocol(this.serverless);
 
       if (Array.isArray(this.options.watch) && this.options.watch.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -128,7 +128,7 @@ class ServerlessAppSyncSimulator {
       }
 
       this.options.lambdaPort = this.getLambdaPort(this.serverless);
-      this.options.httpPort = this.getHttpHost(this.serverless);
+      this.options.httpHost = this.getHttpHost(this.serverless);
       this.options.httpProtocol = this.getHttpProtocol(this.serverless);
 
       if (Array.isArray(this.options.watch) && this.options.watch.length > 0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {
   AmplifyAppSyncSimulator,
   addDataLoader,
-} from '@aws-amplifyamplify-appsync-simulator';
+} from '@aws-amplify/amplify-appsync-simulator';
 import { inspect } from 'util';
 import { defaults, get, merge, reduce } from 'lodash';
 import NodeEvaluator from 'cfn-resolver-lib';
@@ -28,7 +28,7 @@ class ServerlessAppSyncSimulator {
 
     addDataLoader('HTTP', HttpDataLoader);
 
-    // not needed anymore, this loader is registered by the new version of @aws-amplifyamplify-appsync-simulator
+    // not needed anymore, this loader is registered by the new version of @aws-amplify/amplify-appsync-simulator
     // addDataLoader('AMAZON_ELASTICSEARCH', ElasticDataLoader);
     
     addDataLoader('RELATIONAL_DATABASE', RelationalDataLoader);

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ class ServerlessAppSyncSimulator {
 
   getHttpProtocol(context) {
     // Default serverless-offline httpsProtocol is empty
-    let protocol = 'https';
+    let protocol = 'http';
     const offlineConfig = context.service.custom['serverless-offline'];
     // Check if the user has defined a certificate for https as part of their serverless.yml
     if (offlineConfig != undefined && offlineConfig.httpsProtocol != undefined) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,7 @@
 import {
   AmplifyAppSyncSimulator,
-  addDataLoader, getDataLoader
-} from '@aws-amplify/amplify-appsync-simulator';
+  addDataLoader,
+} from '@aws-amplifyamplify-appsync-simulator';
 import { inspect } from 'util';
 import { defaults, get, merge, reduce } from 'lodash';
 import NodeEvaluator from 'cfn-resolver-lib';
@@ -26,23 +26,12 @@ class ServerlessAppSyncSimulator {
 
     this.simulators = null;
 
-    try {
-      getDataLoader('HTTP');
-    } catch (e) {
-      addDataLoader('HTTP', HttpDataLoader);
-    }
+    addDataLoader('HTTP', HttpDataLoader);
 
-    try {
-      getDataLoader('AMAZON_ELASTICSEARCH');
-    } catch (e) {
-      addDataLoader('AMAZON_ELASTICSEARCH', ElasticDataLoader);
-    }
-
-    try {
-      getDataLoader('RELATIONAL_DATABASE');
-    } catch (e) {
-      addDataLoader('RELATIONAL_DATABASE', RelationalDataLoader);
-    }
+    // not needed anymore, this loader is registered by the new version of @aws-amplifyamplify-appsync-simulator
+    // addDataLoader('AMAZON_ELASTICSEARCH', ElasticDataLoader);
+    
+    addDataLoader('RELATIONAL_DATABASE', RelationalDataLoader);
 
     this.hooks = {
       'before:offline:start:init': this.startServers.bind(this),


### PR DESCRIPTION
This PR offers a helper function that backports the new file structure/configuration of amplify-appsync-simulator >= 2.8.0 so that the current serverless-appsync-simulator can work as expected.

It's required to outsource all appsync configurations to an external file. as example `serverless.appsync-api.yml`. In `serverless.yml` it's required to link this file in two places:

```
appSync: ${file(serverless.appsync-api.yml)}

custom:
  appSync:
    - ${file(serverless.appsync-api.yml)}
```

The external file should be in the new format.

**Currently Code (Javascript transformators) are not supported**

I deployed to AWS and it works for me as expected.

In addition to the version update, i added some more granular configuration for local development.

#178 