### PR TITLE
fix: convert port to number type

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -79,8 +79,8 @@ class ServerlessAppSyncSimulator {
 
       this.simulators = [];
       if (Array.isArray(this.serverless.service.custom.appSync)) {
-        let port = this.options.port;
-        let wsPort = this.options.wsPort;
+        let port = Number(this.options.port);
+        let wsPort = Number(this.options.wsPort);
         for (let appSyncConfig of this.serverless.service.custom.appSync) {
           this.simulators.push({
             amplifySimulator: await this.startIndividualServer(port, wsPort),


### PR DESCRIPTION
When using multiple APIs, port is incremented.(See: https://github.com/serverless-appsync/serverless-appsync-simulator/pull/92)
However, when I specified port from the environment variable, it became a string and could not be incremented, resulting in the following error.

```sh
❯ APPSYNC_PORT=20004 npx sls offline start
AppSync Simulator: Error: Port 2000410 is already in use. Please kill the program using this port and restart Mock
...
```

So, I fixed this even if port/wsPort is specified from an environment variable.

